### PR TITLE
fix: [LT-1243] Ensure we add missing trailing slash.

### DIFF
--- a/src/main/java/com/sailthru/sqs/MParticleClient.java
+++ b/src/main/java/com/sailthru/sqs/MParticleClient.java
@@ -103,6 +103,20 @@ public class MParticleClient {
                 .filter(not(String::isEmpty))
                 .orElse(DEFAULT_BASE_URL);
 
-        return apiFactory.create(apiKey, apiSecret, apiURL);
+        return apiFactory.create(apiKey, apiSecret, normalizeUrl(apiURL));
+    }
+
+    private String normalizeUrl(String url) {
+        final int queryIndex = url.indexOf('?');
+        final int slashIndex = queryIndex - 1;
+        if (queryIndex > 0) {
+            if (url.charAt(slashIndex) != '/') {
+                return url.substring(0, queryIndex) + "/" + url.substring(queryIndex);
+            }
+            // fallthrough
+        } else if (!url.endsWith("/")) {
+            return url + "/";
+        }
+        return url;
     }
 }

--- a/src/main/java/com/sailthru/sqs/MessageProcessor.java
+++ b/src/main/java/com/sailthru/sqs/MessageProcessor.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 public class MessageProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageProcessor.class);
-    private static final int MAX_MPARTICLE_MESSAGE_LENGTH = 256 * 1000; // 256 kb - rounded down in case they messed up
+    private static final int MAX_MPARTICLE_MESSAGE_LENGTH = 256 * 1024; // 256 kb
 
     private MessageSerializer messageSerializer;
     private boolean mparticleDisabled;

--- a/src/test/java/com/sailthru/sqs/MParticleClientTest.java
+++ b/src/test/java/com/sailthru/sqs/MParticleClientTest.java
@@ -170,7 +170,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessageWithURL);
 
-        verify(mockApiFactory).create("test_key", "test_secret", "https://test_url.com");
+        verify(mockApiFactory).create("test_key", "test_secret", "https://test_url.com/");
     }
 
     @Test
@@ -189,6 +189,30 @@ public class MParticleClientTest {
         testInstance.submit(validMessage);
 
         verify(mockApiFactory).create("test_key", "test_secret", DEFAULT_BASE_URL);
+    }
+
+    @Test
+    void givenApiURLWithoutTrailingSlashThenTrailingSlashIsAdded() throws NoRetryException, RetryLaterException {
+        final MParticleOutgoingMessage validMessage = givenValidMessage("/messages/valid.json");
+        final String httpbinUrl = "http://httpbin.org/status/200%3A99%2C429%3A1";
+        validMessage.setApiURL(httpbinUrl);
+
+        testInstance.submit(validMessage);
+
+        verify(mockApiFactory).create("test_key", "test_secret", httpbinUrl + "/");
+    }
+
+
+    @Test
+    void givenApiURLWithoutTrailingSlashContainingQueryThenTrailingSlashIsAdded()
+        throws NoRetryException, RetryLaterException {
+        final MParticleOutgoingMessage validMessage = givenValidMessage("/messages/valid.json");
+        final String httpbinUrl = "http://httpbin.org/status/200%3A99%2C429%3A1";
+        validMessage.setApiURL(httpbinUrl + "?test");
+
+        testInstance.submit(validMessage);
+
+        verify(mockApiFactory).create("test_key", "test_secret", httpbinUrl + "/?test");
     }
 
     private MParticleOutgoingMessage givenValidMessage(final String filePath) {

--- a/src/test/java/com/sailthru/sqs/MParticleClientTest.java
+++ b/src/test/java/com/sailthru/sqs/MParticleClientTest.java
@@ -202,7 +202,6 @@ public class MParticleClientTest {
         verify(mockApiFactory).create("test_key", "test_secret", httpbinUrl + "/");
     }
 
-
     @Test
     void givenApiURLWithoutTrailingSlashContainingQueryThenTrailingSlashIsAdded()
         throws NoRetryException, RetryLaterException {

--- a/src/test/java/com/sailthru/sqs/MessageProcessorTest.java
+++ b/src/test/java/com/sailthru/sqs/MessageProcessorTest.java
@@ -99,7 +99,7 @@ public class MessageProcessorTest {
         PayloadTooLargeException exception = assertThrows(PayloadTooLargeException.class,
             () -> testInstance.process(mockSQSMessage));
         System.out.println(exception.getSize());
-        assertThat(exception.getSize(), greaterThan(200_000L));
+        assertThat(exception.getSize(), greaterThan(256 * 1024L));
         verifyNoInteractions(mockMParticleClient);
     }
 

--- a/src/test/resources/messages/too_long.json
+++ b/src/test/resources/messages/too_long.json
@@ -3612,6 +3612,15 @@
         "profile_id": "6634e1bd31a2a0e8af0b0dff",
         "list_id": "5609b2641aa312d6318b456b"
       }
+    },
+    {
+      "eventName": "EMAIL_SUBSCRIBE",
+      "eventType": "OTHER",
+      "additionalData": {
+        "client_id": "3386",
+        "profile_id": "6634e1bd31a2a0e8af0b0dff",
+        "list_id": "5609b2641aa312d6318b456b"
+      }
     }
   ],
   "timestamp": "2024-05-03T13:11:17Z[UTC]"


### PR DESCRIPTION
MParticle uses retrofit2 which does _not_ like a baseUrl which doesn't end with a slash.

Also update the maximum size to 256 real kilobytes (instead of 256,000 bytes) as we tested we can go up to 256 real kilobytes.