### PR TITLE
[LT-1506] LT-1506 cache events API instances

### DIFF
--- a/src/main/java/com/sailthru/sqs/ApiFactory.java
+++ b/src/main/java/com/sailthru/sqs/ApiFactory.java
@@ -3,12 +3,23 @@ package com.sailthru.sqs;
 import com.mparticle.ApiClient;
 import com.mparticle.client.EventsApi;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class ApiFactory {
-    public EventsApi create(final String apiKey, final String apiSecret, final String apiURL) {
-        final ApiClient apiClient = new ApiClient(apiKey, apiSecret);
 
-        apiClient.getAdapterBuilder().baseUrl(apiURL);
+    private static final Map<ClientApiDetails, EventsApi> CACHE = new ConcurrentHashMap<>();
 
-        return apiClient.createService(EventsApi.class);
+    public EventsApi of(final String apiKey, final String apiSecret, final String apiURL) {
+        final ClientApiDetails apiDetails = new ClientApiDetails(apiKey, apiSecret, apiURL);
+        return CACHE.computeIfAbsent(apiDetails, details -> {
+            ApiClient client = new ApiClient(details.apiKey(), details.apiSecret());
+            client.getAdapterBuilder().baseUrl(details.apiURL());
+            return client.createService(EventsApi.class);
+        });
     }
+
+    private record ClientApiDetails(String apiKey, String apiSecret, String apiURL) {
+    }
+
 }

--- a/src/main/java/com/sailthru/sqs/MParticleClient.java
+++ b/src/main/java/com/sailthru/sqs/MParticleClient.java
@@ -108,7 +108,7 @@ public class MParticleClient {
                 .filter(not(String::isEmpty))
                 .orElse(DEFAULT_BASE_URL);
 
-        return apiFactory.create(apiKey, apiSecret, normalizeUrl(apiURL));
+        return apiFactory.of(apiKey, apiSecret, normalizeUrl(apiURL));
     }
 
     private String normalizeUrl(String url) {

--- a/src/test/java/com/sailthru/sqs/MParticleClientTest.java
+++ b/src/test/java/com/sailthru/sqs/MParticleClientTest.java
@@ -62,7 +62,7 @@ public class MParticleClientTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        when(mockApiFactory.create(anyString(), anyString(), anyString())).thenReturn(mockEventsApi);
+        when(mockApiFactory.of(anyString(), anyString(), anyString())).thenReturn(mockEventsApi);
         when(mockEventsApi.uploadEvents(any(Batch.class))).thenReturn(mockCall);
         when(mockCall.execute()).thenReturn(mockResponse);
         testInstance = new MParticleClient(mockApiFactory, Batch.Environment.DEVELOPMENT);
@@ -169,7 +169,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessageWithURL);
 
-        verify(mockApiFactory).create("test_key", "test_secret", "https://test_url.com/");
+        verify(mockApiFactory).of("test_key", "test_secret", "https://test_url.com/");
     }
 
     @Test
@@ -178,7 +178,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessage);
 
-        verify(mockApiFactory).create("test_key", "test_secret", DEFAULT_BASE_URL);
+        verify(mockApiFactory).of("test_key", "test_secret", DEFAULT_BASE_URL);
     }
 
     @Test
@@ -187,7 +187,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessage);
 
-        verify(mockApiFactory).create("test_key", "test_secret", DEFAULT_BASE_URL);
+        verify(mockApiFactory).of("test_key", "test_secret", DEFAULT_BASE_URL);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessage);
 
-        verify(mockApiFactory).create("test_key", "test_secret", httpbinUrl + "/");
+        verify(mockApiFactory).of("test_key", "test_secret", httpbinUrl + "/");
     }
 
     @Test
@@ -210,7 +210,7 @@ public class MParticleClientTest {
 
         testInstance.submit(validMessage);
 
-        verify(mockApiFactory).create("test_key", "test_secret", httpbinUrl + "/?test");
+        verify(mockApiFactory).of("test_key", "test_secret", httpbinUrl + "/?test");
     }
 
     private MParticleOutgoingMessage givenValidMessage(final String filePath) {


### PR DESCRIPTION
Cache events API instances to reuse the internal OkHttpClient instances for better performance and better resource management and to prevent the OutOfMemoryErrors that we observed.