### PR TITLE
fix: [LT-1509] use single connection pool

### DIFF
--- a/src/main/java/com/sailthru/sqs/ApiFactory.java
+++ b/src/main/java/com/sailthru/sqs/ApiFactory.java
@@ -11,6 +11,8 @@ import software.amazon.awssdk.utils.StringUtils;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
 
 public class ApiFactory {
     private static final String HTTP_POOL_KEEPALIVE_SECONDS = "HTTP_POOL_KEEPALIVE_SECONDS";
@@ -20,20 +22,45 @@ public class ApiFactory {
             safeParseInt(System.getenv(HTTP_POOL_KEEPALIVE_SECONDS), 300),
             TimeUnit.SECONDS))
         .build();
-    private static final Map<ClientApiDetails, EventsApi> CACHE = new ConcurrentHashMap<>();
+    // VisibleForTesting
+    static final Map<ClientApiDetails, EventsApi> CACHE = new ConcurrentHashMap<>();
+    private static final ReentrantLock lock = new ReentrantLock();
+
+    private BiFunction<String, String, ApiClient> apiClientFactory = ApiClient::new;
 
     public EventsApi of(final String apiKey, final String apiSecret, final String apiURL) {
         final ClientApiDetails apiDetails = new ClientApiDetails(apiKey, apiSecret, apiURL);
         return CACHE.computeIfAbsent(apiDetails, details -> {
-            ApiClient client = new ApiClient(details.apiKey(), details.apiSecret());
-            // use the same connection pool for everybody
-            client.configureFromOkclient(commonHttpClient);
-            client.getAdapterBuilder().baseUrl(details.apiURL());
-            return client.createService(EventsApi.class);
+            // we can only run one configuration segment at a time, globally, since ApiClient incorrectly
+            // makes its OkHttpClient.Builder a static instance - so if you have multiple threads trying
+            // to construct instances at the same time, you can run into trouble.
+            // This makes the concurrent map slightly less performant, but only if we're hitting contention
+            // due to multiple messages coming up at same time with different cache keys. In steady state
+            // the lock will not be used.
+            //
+            // once the EventsApi instance is returned, we're OK because the OkHttpClient.Builder instance
+            // was already called to obtain a new OkHttpClient instance, which is bound to the Retrofit
+            // object.
+            lock.lock();
+            try {
+                ApiClient client = apiClientFactory.apply(details.apiKey(), details.apiSecret());
+                // use the same connection pool for everybody
+                client.configureFromOkclient(commonHttpClient);
+                client.getAdapterBuilder().baseUrl(details.apiURL());
+                return client.createService(EventsApi.class);
+            } finally {
+                lock.unlock();
+            }
         });
     }
 
-    private record ClientApiDetails(String apiKey, String apiSecret, String apiURL) {
+    // VisibleForTesting
+    void setApiClientFactory(BiFunction<String, String, ApiClient> apiClientFactory) {
+        this.apiClientFactory = apiClientFactory;
+    }
+
+    // VisibleForTesting
+    record ClientApiDetails(String apiKey, String apiSecret, String apiURL) {
     }
 
     private static int safeParseInt(String value, int defaultValue) {

--- a/src/main/java/com/sailthru/sqs/ApiFactory.java
+++ b/src/main/java/com/sailthru/sqs/ApiFactory.java
@@ -2,18 +2,32 @@ package com.sailthru.sqs;
 
 import com.mparticle.ApiClient;
 import com.mparticle.client.EventsApi;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.utils.StringUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class ApiFactory {
-
+    private static final String HTTP_POOL_KEEPALIVE_SECONDS = "HTTP_POOL_KEEPALIVE_SECONDS";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiFactory.class);
+    private static final OkHttpClient commonHttpClient = new OkHttpClient.Builder()
+        .connectionPool(new ConnectionPool(5,
+            safeParseInt(System.getenv(HTTP_POOL_KEEPALIVE_SECONDS), 300),
+            TimeUnit.SECONDS))
+        .build();
     private static final Map<ClientApiDetails, EventsApi> CACHE = new ConcurrentHashMap<>();
 
     public EventsApi of(final String apiKey, final String apiSecret, final String apiURL) {
         final ClientApiDetails apiDetails = new ClientApiDetails(apiKey, apiSecret, apiURL);
         return CACHE.computeIfAbsent(apiDetails, details -> {
             ApiClient client = new ApiClient(details.apiKey(), details.apiSecret());
+            // use the same connection pool for everybody
+            client.configureFromOkclient(commonHttpClient);
             client.getAdapterBuilder().baseUrl(details.apiURL());
             return client.createService(EventsApi.class);
         });
@@ -22,4 +36,15 @@ public class ApiFactory {
     private record ClientApiDetails(String apiKey, String apiSecret, String apiURL) {
     }
 
+    private static int safeParseInt(String value, int defaultValue) {
+        if (StringUtils.isBlank(value)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Unable to parse value '{}' as an integer, will use default {}", value, defaultValue);
+            return defaultValue;
+        }
+    }
 }

--- a/src/test/java/com/sailthru/sqs/ApiFactoryTest.java
+++ b/src/test/java/com/sailthru/sqs/ApiFactoryTest.java
@@ -1,0 +1,180 @@
+package com.sailthru.sqs;
+
+import com.mparticle.ApiClient;
+import com.mparticle.client.EventsApi;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import retrofit2.Retrofit;
+import software.amazon.awssdk.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.random.RandomGenerator;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ApiFactoryTest {
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private ApiClient mockClient;
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Retrofit.Builder mockAdapterBuilder;
+    @Mock
+    private EventsApi mockEventsApi;
+    private List<Pair<String, String>> keysAndSecrets;
+    private ApiFactory apiFactory;
+    private AtomicInteger currentCallCounter;
+    private AtomicInteger maxConcurrentCalls;
+
+    @BeforeEach
+    void beforeEach() {
+        keysAndSecrets = new ArrayList<>();
+        currentCallCounter = new AtomicInteger(0);
+        maxConcurrentCalls = new AtomicInteger(0);
+        apiFactory = givenApiFactory();
+        configureMockClient(mockEventsApi);
+        ApiFactory.CACHE.clear();
+    }
+
+    private void configureMockClient(EventsApi mockEventsApi1) {
+        reset(mockClient);
+        when(mockClient.getAdapterBuilder()).thenReturn(mockAdapterBuilder);
+        when(mockClient.createService(eq(EventsApi.class))).thenReturn(mockEventsApi1);
+    }
+
+    @Test
+    void givenSingleKeyAndApiThenClientConfiguredAsExpected() {
+        final EventsApi api = apiFactory.of("test", "test", "test");
+
+        verify(mockClient).configureFromOkclient(any());
+        verify(mockAdapterBuilder).baseUrl("test");
+        verify(mockClient).createService(EventsApi.class);
+        assertThat(ApiFactory.CACHE.size(), equalTo(1));
+    }
+
+    @Test
+    void givenMultipleKeysAndApiThenClientsAreConfiguredAsExpected() {
+        final EventsApi api1 = apiFactory.of("test", "test", "test");
+        final EventsApi api2 = apiFactory.of("test", "test", "test2");
+        final EventsApi api3 = apiFactory.of("test2", "test", "test");
+        final EventsApi api4 = apiFactory.of("test", "test2", "test");
+
+        final InOrder inOrder = Mockito.inOrder(mockClient, mockAdapterBuilder);
+        final ArgumentCaptor<OkHttpClient> captor = ArgumentCaptor.forClass(OkHttpClient.class);
+        inOrder.verify(mockClient).configureFromOkclient(captor.capture());
+        inOrder.verify(mockAdapterBuilder).baseUrl("test");
+        inOrder.verify(mockClient).createService(EventsApi.class);
+        inOrder.verify(mockClient).configureFromOkclient(captor.capture());
+        inOrder.verify(mockAdapterBuilder).baseUrl("test2");
+        inOrder.verify(mockClient).createService(EventsApi.class);
+        inOrder.verify(mockClient).configureFromOkclient(captor.capture());
+        inOrder.verify(mockAdapterBuilder).baseUrl("test");
+        inOrder.verify(mockClient).createService(EventsApi.class);
+        inOrder.verify(mockClient).configureFromOkclient(captor.capture());
+        inOrder.verify(mockAdapterBuilder).baseUrl("test");
+        inOrder.verify(mockClient).createService(EventsApi.class);
+        inOrder.verifyNoMoreInteractions();
+        verifyAllCapturedOkHttpClientsAreSameInstance(captor);
+        assertThat(keysAndSecrets,
+            equalTo(List.of(
+                Pair.of("test", "test"),
+                Pair.of("test", "test"),
+                Pair.of("test2", "test"),
+                Pair.of("test", "test2")
+            )));
+        assertThat(ApiFactory.CACHE.size(), equalTo(4));
+    }
+
+    @Test
+    void givenMultipleKeysAndApiRequestedInParallelThenOnlyOneClientWasConfiguredAtATime() {
+        IntStream.range(0, 10)
+            .mapToObj(i -> givenApiFactory())
+            .parallel()
+            .forEach(apiF ->
+                IntStream.range(0, 10)
+                    .parallel()
+                    .forEach(i -> apiF.of("test", "test", "test" + i))
+            );
+
+        assertThat(maxConcurrentCalls.get(), equalTo(1));
+        final ArgumentCaptor<OkHttpClient> captor = ArgumentCaptor.forClass(OkHttpClient.class);
+        verify(mockClient, times(10)).configureFromOkclient(captor.capture());
+        IntStream.range(0, 10)
+                .forEach(i -> verify(mockAdapterBuilder).baseUrl("test" + i));
+        verify(mockClient, times(10)).createService(EventsApi.class);
+        verifyNoMoreInteractions(mockClient, mockAdapterBuilder);
+        verifyAllCapturedOkHttpClientsAreSameInstance(captor);
+        assertThat(ApiFactory.CACHE.size(), equalTo(10));
+    }
+
+    @Test
+    void givenMultipleKeysButNeverCachedWithParallelRequestsThenOnlyOneAttemptToConfigureWasMadeAtATime() {
+        configureMockClient(null);
+        IntStream.range(0, 10)
+            .mapToObj(i -> givenApiFactory())
+            .parallel()
+            .forEach(apiF ->
+                IntStream.range(0, 10)
+                    .parallel()
+                    .forEach(i -> apiF.of("test", "test", "test" + i))
+            );
+
+        assertThat(maxConcurrentCalls.get(), equalTo(1));
+        final ArgumentCaptor<OkHttpClient> captor = ArgumentCaptor.forClass(OkHttpClient.class);
+        verify(mockClient, times(100)).configureFromOkclient(captor.capture());
+        IntStream.range(0, 10)
+            .forEach(i -> verify(mockAdapterBuilder, times(10)).baseUrl("test" + i));
+        verify(mockClient, times(100)).createService(EventsApi.class);
+        verifyNoMoreInteractions(mockClient, mockAdapterBuilder);
+        verifyAllCapturedOkHttpClientsAreSameInstance(captor);
+        assertThat(ApiFactory.CACHE.size(), equalTo(0));
+    }
+
+    private static void verifyAllCapturedOkHttpClientsAreSameInstance(ArgumentCaptor<OkHttpClient> captor) {
+        assertThat(captor.getAllValues()
+            .stream()
+            .map(c -> System.identityHashCode(c))
+            .distinct()
+            .count(), equalTo(1L));
+    }
+
+    private ApiFactory givenApiFactory() {
+        final ApiFactory apiFactory = new ApiFactory();
+        apiFactory.setApiClientFactory((key, secret) -> {
+            currentCallCounter.incrementAndGet();
+            try {
+                // sleep to increase the chance of concurrency
+                Thread.sleep(RandomGenerator.getDefault().nextInt(10));
+                keysAndSecrets.add(Pair.of(key, secret));
+                return mockClient;
+            } catch (InterruptedException e) {
+                fail("interrupted");
+                return null;
+            } finally {
+                final int currentCallCount = currentCallCounter.getAndDecrement();
+                maxConcurrentCalls.getAndAccumulate(currentCallCount, Math::max);
+            }
+        });
+        return apiFactory;
+    }
+}


### PR DESCRIPTION
Although we added a cache for ApiClient, they each end up with their own connection pool. Slightly worse, the implementation is a bit brittle if we do want to add concurrency/threads because that stupid ApiClient from mparticle stores the builder in a static... but resets it on each constructor call :(

There's a lot of trickery involved here because of that static, but the implementation here covers all pitfalls at the cost of a _slight_ performance penalty if threads stampede the cache (however creating an OkHttpClient should be pretty lightweight if the pool is already created - everything else is pretty stateless). Once the cache is warmed we should get excellent performance (and even if it's not we'll only get somewhat bad performance if we have mixed messages from several clients to handle)